### PR TITLE
Recycle TypedArray when Initializing Attributes.

### DIFF
--- a/codeinputlib/src/main/java/com/github/glomadrian/codeinputlib/CodeInput.java
+++ b/codeinputlib/src/main/java/com/github/glomadrian/codeinputlib/CodeInput.java
@@ -137,6 +137,8 @@ public class CodeInput extends View {
         hintText = attributes.getString(R.styleable.core_area_hint_text);
         underlineAmount = attributes.getInt(R.styleable.core_area_codes, underlineAmount);
         textColor = attributes.getInt(R.styleable.core_area_text_color, textColor);
+        
+        attributes.recycle();
     }
 
     private void initDataStructures() {


### PR DESCRIPTION
First, Thanks for awesome library. This is really what I wanted.
I found an small issue that TypedArray didn't release from memory after use.
So I add `recycle()` when initializing attributes are done.